### PR TITLE
feat: Support passing a custom UserManager implementation

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -62,6 +62,11 @@ export interface AuthProviderProps extends UserManagerSettings {
      * On sign out popup hook. Can be a async function.
      */
     onSignoutPopup?: () => Promise<void> | void;
+
+    /**
+     * Allow passing a custom UserManager implementation
+     */
+    implementation?: typeof UserManager;
 }
 
 const userManagerContextKeys = [
@@ -74,9 +79,10 @@ const userManagerContextKeys = [
     "startSilentRenew",
     "stopSilentRenew",
 ] as const;
-const unsupportedEnvironment = (name: string) => () => {
-    throw new Error(`\`${name}()\` was called from an unsupported context`);
+const unsupportedEnvironment = () => {
+    throw new Error("a UserManager method was called from an unsupported context. If this is a server-rendered page, defer this call with useEffect() or pass a custom UserManager implementation.");
 };
+const defaultUserManagerImpl = typeof window === "undefined" ? null : UserManager;
 
 /**
  * Provides the AuthContext to its child components.
@@ -92,12 +98,11 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
         onSignoutRedirect,
         onSignoutPopup,
 
+        implementation: UserManagerImpl = defaultUserManagerImpl,
         ...userManagerProps
     } = props;
 
-    const [userManager] = React.useState(() =>
-        typeof window === "undefined" ? null : new UserManager(userManagerProps)
-    );
+    const [userManager] = React.useState(() => UserManagerImpl && new UserManagerImpl(userManagerProps));
     const [state, dispatch] = React.useReducer(reducer, initialAuthState);
     const userManagerContext = React.useMemo(
         () => ({
@@ -107,7 +112,7 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
                     key,
                     userManager
                         ? userManager[key].bind(userManager)
-                        : unsupportedEnvironment(key),
+                        : unsupportedEnvironment,
                 ])
             ) as Pick<UserManager, typeof userManagerContextKeys[number]>),
         }),
@@ -159,31 +164,34 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
         };
     }, [userManager]);
 
-    const removeUser = React.useMemo(() => userManager
-        ? async (): Promise<void> => {
-            await userManager.removeUser();
-            onRemoveUser && onRemoveUser();
-        }
-        : unsupportedEnvironment("removeUser"),
-    [userManager, onRemoveUser]
+    const removeUser = React.useMemo(
+        () => userManager
+            ? async (): Promise<void> => {
+                await userManager.removeUser();
+                onRemoveUser && onRemoveUser();
+            }
+            : unsupportedEnvironment,
+        [userManager, onRemoveUser]
     );
 
-    const signoutRedirect = React.useMemo(() => userManager
-        ? async (args?: any): Promise<void> => {
-            await userManager.signoutRedirect(args);
-            onSignoutRedirect && onSignoutRedirect();
-        }
-        : unsupportedEnvironment("signoutRedirect"),
-    [userManager, onSignoutRedirect]
+    const signoutRedirect = React.useMemo(
+        () => userManager
+            ? async (args?: any): Promise<void> => {
+                await userManager.signoutRedirect(args);
+                onSignoutRedirect && onSignoutRedirect();
+            }
+            : unsupportedEnvironment,
+        [userManager, onSignoutRedirect]
     );
 
-    const signoutPopup = React.useMemo(() => userManager
-        ? async (args?: any): Promise<void> => {
-            await userManager.signoutPopup(args);
-            onSignoutPopup && onSignoutPopup();
-        }
-        : unsupportedEnvironment("signoutPopup"),
-    [userManager, onSignoutPopup]
+    const signoutPopup = React.useMemo(
+        () => userManager
+            ? async (args?: any): Promise<void> => {
+                await userManager.signoutPopup(args);
+                onSignoutPopup && onSignoutPopup();
+            }
+            : unsupportedEnvironment,
+        [userManager, onSignoutPopup]
     );
 
     return (

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -79,8 +79,8 @@ const userManagerContextKeys = [
     "startSilentRenew",
     "stopSilentRenew",
 ] as const;
-const unsupportedEnvironment = () => {
-    throw new Error("a UserManager method was called from an unsupported context. If this is a server-rendered page, defer this call with useEffect() or pass a custom UserManager implementation.");
+const unsupportedEnvironment = (fnName: string) => () => {
+    throw new Error(`UserManager#${fnName} was called from an unsupported context. If this is a server-rendered page, defer this call with useEffect() or pass a custom UserManager implementation.`);
 };
 const defaultUserManagerImpl = typeof window === "undefined" ? null : UserManager;
 
@@ -112,7 +112,7 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
                     key,
                     userManager
                         ? userManager[key].bind(userManager)
-                        : unsupportedEnvironment,
+                        : unsupportedEnvironment(key),
                 ])
             ) as Pick<UserManager, typeof userManagerContextKeys[number]>),
         }),
@@ -166,31 +166,22 @@ export const AuthProvider = (props: AuthProviderProps): JSX.Element => {
 
     const removeUser = React.useMemo(
         () => userManager
-            ? async (): Promise<void> => {
-                await userManager.removeUser();
-                onRemoveUser && onRemoveUser();
-            }
-            : unsupportedEnvironment,
+            ? () => userManager.removeUser().then(onRemoveUser)
+            : unsupportedEnvironment("removeUser"),
         [userManager, onRemoveUser]
     );
 
     const signoutRedirect = React.useMemo(
         () => userManager
-            ? async (args?: any): Promise<void> => {
-                await userManager.signoutRedirect(args);
-                onSignoutRedirect && onSignoutRedirect();
-            }
-            : unsupportedEnvironment,
+            ? (args?: any) => userManager.signoutRedirect(args).then(onSignoutRedirect)
+            : unsupportedEnvironment("signoutRedirect"),
         [userManager, onSignoutRedirect]
     );
 
     const signoutPopup = React.useMemo(
         () => userManager
-            ? async (args?: any): Promise<void> => {
-                await userManager.signoutPopup(args);
-                onSignoutPopup && onSignoutPopup();
-            }
-            : unsupportedEnvironment,
+            ? (args?: any) => userManager.signoutPopup(args).then(onSignoutPopup)
+            : unsupportedEnvironment("signoutPopup"),
         [userManager, onSignoutPopup]
     );
 

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -66,7 +66,7 @@ export interface AuthProviderProps extends UserManagerSettings {
     /**
      * Allow passing a custom UserManager implementation
      */
-    implementation?: typeof UserManager;
+    implementation?: typeof UserManager | null;
 }
 
 const userManagerContextKeys = [

--- a/test/AuthProvider.test.tsx
+++ b/test/AuthProvider.test.tsx
@@ -172,4 +172,20 @@ describe("AuthProvider", () => {
         expect(UserManager.prototype.signinRedirect).not.toHaveBeenCalled()
         expect(CustomUserManager.prototype.signinRedirect).toHaveBeenCalled()
     })
+
+    it("should should throw when no UserManager implementation exists", async () => {
+        // arrange
+        const wrapper = createWrapper({ implementation: null })
+        const { result } = renderHook(() => useAuth(), {
+            wrapper,
+        })
+
+        // act
+        await expect(act(async () => {
+            result.current.signinRedirect()
+        })).rejects.toThrow()
+
+        // assert
+        expect(UserManager.prototype.signinRedirect).not.toHaveBeenCalled()
+    })
 })

--- a/test/AuthProvider.test.tsx
+++ b/test/AuthProvider.test.tsx
@@ -1,12 +1,11 @@
 import { UserManager, User } from "oidc-client"
-import { act} from "@testing-library/react"
+import { act } from "@testing-library/react"
 import { renderHook } from "@testing-library/react-hooks"
 import { mocked } from "ts-jest/utils"
 
 import { useAuth } from "../src/useAuth"
 import { createWrapper } from "./helpers"
 
-const userManagerMock = mocked(new UserManager({ client_id: "" }))
 const user = { id_token: "__test_user__" } as User
 
 describe("AuthProvider", () => {
@@ -25,8 +24,8 @@ describe("AuthProvider", () => {
         })
 
         // assert
-        expect(userManagerMock.signinRedirect).toHaveBeenCalled()
-        expect(userManagerMock.getUser).toHaveBeenCalled()
+        expect(UserManager.prototype.signinRedirect).toHaveBeenCalled()
+        expect(UserManager.prototype.getUser).toHaveBeenCalled()
     })
 
     it("should handle signinCallback success and call onSigninCallback", async () => {
@@ -50,7 +49,7 @@ describe("AuthProvider", () => {
         await waitForNextUpdate()
 
         // assert
-        expect(userManagerMock.signinCallback).toHaveBeenCalled()
+        expect(UserManager.prototype.signinCallback).toHaveBeenCalled()
         expect(onSigninCallback).toHaveBeenCalled()
     })
 
@@ -75,7 +74,7 @@ describe("AuthProvider", () => {
         await waitForNextUpdate()
 
         // assert
-        expect(userManagerMock.signinCallback).toHaveBeenCalled()
+        expect(UserManager.prototype.signinCallback).toHaveBeenCalled()
         expect(onSigninCallback).toHaveBeenCalled()
     })
 
@@ -95,7 +94,7 @@ describe("AuthProvider", () => {
         })
 
         // assert
-        expect(userManagerMock.removeUser).toHaveBeenCalled()
+        expect(UserManager.prototype.removeUser).toHaveBeenCalled()
         expect(onRemoveUser).toHaveBeenCalled()
     })
 
@@ -114,7 +113,7 @@ describe("AuthProvider", () => {
         })
 
         // assert
-        expect(userManagerMock.signoutRedirect).toHaveBeenCalled()
+        expect(UserManager.prototype.signoutRedirect).toHaveBeenCalled()
         expect(onSignoutRedirect).toHaveBeenCalled()
     })
 
@@ -133,13 +132,13 @@ describe("AuthProvider", () => {
         })
 
         // assert
-        expect(userManagerMock.signoutPopup).toHaveBeenCalled()
+        expect(UserManager.prototype.signoutPopup).toHaveBeenCalled()
         expect(onSignoutPopup).toHaveBeenCalled()
     })
 
     it("should get the user", async () => {
         // arrange
-        userManagerMock.getUser.mockResolvedValue(user)
+        mocked(UserManager.prototype).getUser.mockResolvedValueOnce(user)
         const wrapper = createWrapper()
 
         // act
@@ -150,5 +149,27 @@ describe("AuthProvider", () => {
 
         // assert
         expect(result.current.user).toBe(user)
-      })
+    })
+
+    it("should use a custom UserManager implementation", async () => {
+        // arrange
+        class CustomUserManager extends UserManager { }
+        mocked(CustomUserManager.prototype).signinRedirect = jest.fn();
+
+        const wrapper = createWrapper({ implementation: CustomUserManager })
+        const { waitForNextUpdate, result } = renderHook(() => useAuth(), {
+            wrapper,
+        })
+        await waitForNextUpdate()
+        expect(result.current.user).toBeUndefined()
+
+        // act
+        await act(async () => {
+            result.current.signinRedirect()
+        })
+
+        // assert
+        expect(UserManager.prototype.signinRedirect).not.toHaveBeenCalled()
+        expect(CustomUserManager.prototype.signinRedirect).toHaveBeenCalled()
+    })
 })

--- a/test/__mocks__/oidc-client.ts
+++ b/test/__mocks__/oidc-client.ts
@@ -1,70 +1,50 @@
-const clearStaleState = jest.fn()
-const getUser = jest.fn()
-const storeUser = jest.fn()
-const removeUser = jest.fn()
-const signinPopup = jest.fn()
-const signinPopupCallback = jest.fn()
-const signinSilent = jest.fn()
-const signinSilentCallback = jest.fn()
-const signinRedirect = jest.fn()
-const signinRedirectCallback = jest.fn()
-const signoutRedirect = jest.fn()
-const signoutRedirectCallback = jest.fn()
-const signoutPopup = jest.fn()
-const signoutPopupCallback = jest.fn()
-const signinCallback = jest.fn()
-const signoutCallback = jest.fn()
-const querySessionStatus = jest.fn()
-const revokeAccessToken = jest.fn()
-const startSilentRenew = jest.fn()
-const stopSilentRenew = jest.fn()
+import type { UserManager, UserManagerEvents } from 'oidc-client'
 
-const events = {
-    load: jest.fn(),
-    unload: jest.fn(),
+const MockUserManager: typeof UserManager = jest.fn(function (this: { events: Partial<UserManagerEvents>}) {
+    this.events = {
+        load: jest.fn(),
+        unload: jest.fn(),
 
-    addUserLoaded: jest.fn(),
-    removeUserLoaded: jest.fn(),
+        addUserLoaded: jest.fn(),
+        removeUserLoaded: jest.fn(),
 
-    addUserUnloaded: jest.fn(),
-    removeUserUnloaded: jest.fn(),
+        addUserUnloaded: jest.fn(),
+        removeUserUnloaded: jest.fn(),
 
-    addSilentRenewError: jest.fn(),
-    removeSilentRenewError: jest.fn(),
+        addSilentRenewError: jest.fn(),
+        removeSilentRenewError: jest.fn(),
 
-    addUserSignedIn: jest.fn(),
-    removeUserSignedIn: jest.fn(),
+        addUserSignedIn: jest.fn(),
+        removeUserSignedIn: jest.fn(),
 
-    addUserSignedOut: jest.fn(),
-    removeUserSignedOut: jest.fn(),
+        addUserSignedOut: jest.fn(),
+        removeUserSignedOut: jest.fn(),
 
-    addUserSessionChanged: jest.fn(),
-    removeUserSessionChanged: jest.fn(),
-}
-
-export const UserManager = jest.fn(() => {
-    return {
-        clearStaleState,
-        getUser,
-        storeUser,
-        removeUser,
-        signinPopup,
-        signinPopupCallback,
-        signinSilent,
-        signinSilentCallback,
-        signinRedirect,
-        signinRedirectCallback,
-        signoutRedirect,
-        signoutRedirectCallback,
-        signoutPopup,
-        signoutPopupCallback,
-        signinCallback,
-        signoutCallback,
-        querySessionStatus,
-        revokeAccessToken,
-        startSilentRenew,
-        stopSilentRenew,
-
-        events,
+        addUserSessionChanged: jest.fn(),
+        removeUserSessionChanged: jest.fn(),
     }
+
+    return this as UserManager
 })
+MockUserManager.prototype.clearStaleState = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.getUser = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.storeUser = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.removeUser = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signinPopup = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signinPopupCallback = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signinSilent = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signinSilentCallback = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signinRedirect = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signinRedirectCallback = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signoutRedirect = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signoutRedirectCallback = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signoutPopup = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signoutPopupCallback = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signinCallback = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.signoutCallback = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.querySessionStatus = jest.fn().mockResolvedValue(undefined)
+MockUserManager.prototype.revokeAccessToken = jest.fn()
+MockUserManager.prototype.startSilentRenew = jest.fn()
+MockUserManager.prototype.stopSilentRenew = jest.fn()
+
+export { MockUserManager as UserManager }


### PR DESCRIPTION
This is building off of the SSR support from earlier - I've added an optional `implementation` prop to `AuthProvider`. In a browser environment with `window`, the default value is the out-of-the-box `UserManager` class from oidc-client.

This approach allows someone to build a custom `UserManager` class that supports a server-side environment. I also have a use case where I want to do some preprocessing in the `*Callback()` functions before I hand off to UserManager.